### PR TITLE
Multilayer reflectivity

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,11 @@
+* v0.2.0
+- add ~refractedAngle~, ~refractedAngleSin~ to get refracted angle
+  after an interface (and the ~sin(θ_j)~ in the latter case)
+- add ~energy~ to convert a wavelength back to an energy
+- add support for depth graded multilayer reflections, i.e. like the
+  LLNL telescope (NuSTAR optic)
+- improve ~reflectivity~ implementation
+- allow calculation of refractive indices for compounds  
 * v0.1.3
 - add ~transmission~ overload for convenience taking a compound,
   density, length and energy

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,12 @@
+* v0.2.1
+- Elements now have a density field as well, which can be handed to the
+  ~init~ call (in the future we might look them up as well).
+- Compounds can also be given a density in the ~compound~ macro by
+  providing a ~ρ~ or ~density~ argument.
+- The ~DepthGradedMultilayer~ type takes care of constructing the
+  correct refractive indices & layers for such a coating.
+- add ~depthGradedLayers~ helper to compute the layer thicknesses
+  according to the equations for depth graded layers
 * v0.2.0
 - add ~refractedAngle~, ~refractedAngleSin~ to get refracted angle
   after an interface (and the ~sin(θ_j)~ in the latter case)
@@ -12,7 +21,7 @@
 * v0.1.2
 - add ~FluroscenceLine~ type and CSV file:
   CSV file contains all known X-ray fluorescence lines and their
-  intensities. Using `getFluorescenceLines` the user can get all lines,
+  intensities. Using ~getFluorescenceLines~ the user can get all lines,
   their names and their relative intensities (be careful to
   normalize!).
 - add ~GasMixture~ type and option to compute absorption length and

--- a/changelog.org
+++ b/changelog.org
@@ -7,6 +7,9 @@
   correct refractive indices & layers for such a coating.
 - add ~depthGradedLayers~ helper to compute the layer thicknesses
   according to the equations for depth graded layers
+- export ~ρ~ field for compounds
+- add ~density~ for gas mixtures to get density of the mixture
+- add ~transmission~ to compute the transmission of gas mixtures      
 * v0.2.0
 - add ~refractedAngle~, ~refractedAngleSin~ to get refracted angle
   after an interface (and the ~sin(θ_j)~ in the latter case)

--- a/playground/testing.nim
+++ b/playground/testing.nim
@@ -9,58 +9,191 @@ Element[77].init().plotAttenuation()
 echo readMolarMasses()
 
 let ar = Argon.init()
-#let ρ_Ar = density(1050.mbar.to(Pascal), 293.K, ar.molarMass)
+let ρ_Ar = density(1050.mbar.to(Pascal), 293.K, ar.molarMass)
 #let ρ_Ar = density((1400 * 0.973).mbar.to(Pascal), 300.K, ar.molarMass)
-ar.plotAttenuation()
+ar.plotAttenuation(logLog = true)
 ## XXX:: the following with typo `enrgyMin` causes a compiler segfault!
 ## ar.plotTransmission(ρ_Ar, 3.cm.to(m), enrgyMin = 5.5, energyMax = 6.5)
 ar.plotTransmission(ρ_Ar, 3.cm.to(m), energyMin = 5.5, energyMax = 6.5)
-block ArgonTrans:
-  let μ_Ar = ar.attenuationCoefficient(5.9.keV)
-  let t = transmission(μ_Ar, ρ_Ar, 3.cm.to(Meter))
-  echo "Trasmission at 5.9 keV = ", t
-
-echo absorptionLength(2.5.keV, numberDensity(ρ_Ar, ar.molarMass),
-                      ar.f2eval(2.5.keV))
-echo ar.absorptionLength(ρ_Ar, 2.5.keV)
-
+#block ArgonTrans:
+#  let μ_Ar = ar.attenuationCoefficient(5.9.keV)
+#  let t = transmission(μ_Ar, ρ_Ar, 3.cm.to(Meter))
+#  echo "Trasmission at 5.9 keV = ", t
+#
+#echo absorptionLength(2.5.keV, numberDensity(ρ_Ar, ar.molarMass),
+#                      ar.f2eval(2.5.keV))
+#echo ar.absorptionLength(ρ_Ar, 2.5.keV)
+#
 let au = Gold.init()
 let ρ_Au = 19.32.g•cm⁻³
 echo "num density Gold: ", numberDensity(ρ_Au, au.molarMass), " vs ", numberDensity(ρ_Ar, ar.molarMass)
-#if true: quit()
+##if true: quit()
 let df = au.plotReflectivity(ρ_Au, 0.5.Degree) #, 0.5.Degree)
-
-let Si₃N₄ = compound((Si, 3), (N, 4))
-Si₃N₄.plotTransmission(3.44.g•cm⁻³, 300.nm.to(Meter))
-
+#
+#let Si₃N₄ = compound((Si, 3), (N, 4))
+#Si₃N₄.plotTransmission(3.44.g•cm⁻³, 300.nm.to(Meter))
+#
 let mylar = compound((C, 10), (H, 8), (O, 4))
-mylar.plotTransmission(1.4.g•cm⁻³, 2.μm.to(Meter), energyMax = 3.0)
+mylar.plotTransmission(1.4.g•cm⁻³, 4.μm.to(Meter), energyMax = 10.0)
+#
+#echo Si₃N₄.absorptionLength(3.44.g•cm⁻³, 2.5.keV)
+#
+#block TestCompareWithHenke:
+#  let df = toDf({"Energy[keV]" : linspace(0.03, 10.0, 1000)})
+#    .mutate(f{float: "μ" ~ Si₃N₄.attenuationCoefficient(idx("Energy[keV]").keV).float},
+#            f{float: "Trans" ~ transmission(`μ`.cm²•g⁻¹, 3.44.g•cm⁻³, 300.nm.to(Meter)).float},
+#            f{float: "Abs" ~ 1.0 - `Trans`})
+#  let dfR = readCsv("/home/basti/org/resources/Si3N4_density_3.44_thickness_0.3microns.txt", sep = ' ')
+#    .mutate(f{"Energy[keV]" ~ idx("PhotonEnergy(eV)") / 1000.0})
+#  echo dfR
+#  ggplot(df, aes("Energy[keV]")) +
+#    geom_line(aes = aes(y = "Trans")) +
+#    geom_line(data = dfR, aes = aes("Energy[keV]", "Transmission"), lineType = ltDashed, color = "red") +
+#    ggtitle(&"Transmission for Si₃N₄ thickness = {300.nm}, at ρ = {3.44.g•cm⁻³}") +
+#    ggsave("/tmp/transmission_si3n4_300nm.pdf", width = 800, height = 480)
+#
+#block TestCompareAuReflectivityHenke:
+#  let dfR = readCsv(
+#    "../resources/reflectivity_gold_0_5deg.txt", sep = ' ', skipLines = 2,
+#    colNames = @["Energy[eV]", "Reflectivity"])
+#    .mutate(f{"Energy[keV]" ~ idx("Energy[eV]") / 1000.0})
+#  echo dfR
+#  ggplot(df, aes("Energy[keV]")) +
+#    geom_line(aes = aes(y = "Rs")) +
+#    xlim(0.0, 2.0) + ylim(0.85, 1.0) +
+#    geom_line(data = dfR, aes = aes("Energy[keV]", "Reflectivity"), lineType = ltDashed, color = "red") +
+#    ggtitle(&"Reflectivity Gold at θ = {0.5.°}, at ρ = {19.32.g•cm⁻³}") +
+#    ggsave("/tmp/reflectivity_gold_0_5.deg.pdf", width = 800, height = 480)
 
-echo Si₃N₄.absorptionLength(3.44.g•cm⁻³, 2.5.keV)
 
-block TestCompareWithHenke:
-  let df = toDf({"Energy[keV]" : linspace(0.03, 10.0, 1000)})
-    .mutate(f{float: "μ" ~ Si₃N₄.attenuationCoefficient(idx("Energy[keV]").keV).float},
-            f{float: "Trans" ~ transmission(`μ`.cm²•g⁻¹, 3.44.g•cm⁻³, 300.nm.to(Meter)).float},
-            f{float: "Abs" ~ 1.0 - `Trans`})
-  let dfR = readCsv("/home/basti/org/resources/Si3N4_density_3.44_thickness_0.3microns.txt", sep = ' ')
-    .mutate(f{"Energy[keV]" ~ idx("PhotonEnergy(eV)") / 1000.0})
-  echo dfR
-  ggplot(df, aes("Energy[keV]")) +
-    geom_line(aes = aes(y = "Trans")) +
-    geom_line(data = dfR, aes = aes("Energy[keV]", "Transmission"), lineType = ltDashed, color = "red") +
-    ggtitle(&"Transmission for Si₃N₄ thickness = {300.nm}, at ρ = {3.44.g•cm⁻³}") +
-    ggsave("/tmp/transmission_si3n4_300nm.pdf", width = 800, height = 480)
+import sequtils, ggplotnim
+block LLNL_Reflectivity:
+#when false:
+  #[
+Reference:
+let m1 = drp.Multilayer(MultilayerType="DepthGraded",
+                        SubstrateMaterial="SiO2",
+                        D_min = 11.5,
+                        D_max = 22.5,
+                        Gamma = 0.45,
+                        C = 1.0,
+                        LayerMaterial=["C", "Pt"],
+                        Repetition=2,
+                        SigmaValues=[1.0])
+]#
 
-block TestCompareAuReflectivityHenke:
-  let dfR = readCsv(
-    "../resources/reflectivity_gold_0_5deg.txt", sep = ' ', skipLines = 2,
-    colNames = @["Energy[eV]", "Reflectivity"])
-    .mutate(f{"Energy[keV]" ~ idx("Energy[eV]") / 1000.0})
-  echo dfR
-  ggplot(df, aes("Energy[keV]")) +
-    geom_line(aes = aes(y = "Rs")) +
-    xlim(0.0, 2.0) + ylim(0.85, 1.0) +
-    geom_line(data = dfR, aes = aes("Energy[keV]", "Reflectivity"), lineType = ltDashed, color = "red") +
-    ggtitle(&"Reflectivity Gold at θ = {0.5.°}, at ρ = {19.32.g•cm⁻³}") +
-    ggsave("/tmp/reflectivity_gold_0_5.deg.pdf", width = 800, height = 480)
+  # initalize the elements of the substrate
+  let C = Carbon.init()
+  let Pt = Platinum.init()
+  let glass = compound((Si, 1), (O, 2)) # pure quartz glass
+  const ρC = 2.26.g•cm⁻³ # 2.267 should be correct. used number same as DarpanX however
+  const ρPt = 21.41.g•cm⁻³ # 21.45 should be correct. used number same as DarpanX however
+  const ρGlass = 2.65.g•cm⁻³
+  const θ = 0.5.°
+
+  if false:
+    echo 0.03.keV.wavelength().m.to(nm)
+    echo "to"
+    echo 10.keV.wavelength().m.to(nm)
+    quit()
+
+  block RefractiveIndexDebug:
+    let λ = 1.976788861549859121e2.nm
+    echo λ.energy()
+    let nC = refractiveIndex(C, λ.energy(), ρC)
+    echo "Ours = ", nC
+    let target = complex(1.705354170365389610, 0.000000000000000000)
+    echo "Target = ", target
+
+  block RefrIndexGlass:
+    echo glass.molarWeight(), " to target: #A(g/mol)=60.0843"
+    #[
+#Formula=SiO2
+#A(g/mol)=60.0843
+#Rho(g/cm3)=2.65
+#Energy range=0.006958-432.9451 keV
+#
+# Wavelength (A) 	 n  	 k
+1.781894185059028132e+03 2.009538984318353094e+00 5.633583284510720324e-01
+1.755031458651102866e+03 2.740088255913744497e+00 5.342169546214327047e-01
+1.748004305663511332e+03 3.617751372225351147e+00 5.267290442116252525e-01
+]#
+    # let λ = 1.781894185059028132e2.nm
+
+    proc checkLambda(λ: nm, target: Complex[float]) =
+      echo "At energy: ", λ.energy()
+      let nGlass = refractiveIndex(glass, λ.energy(), ρGlass)
+      echo "⇒⇒⇒⇒Ours = ", nGlass
+      echo "⇒⇒⇒⇒Target = ", target
+    let λ = 1.516483801844758261.nm
+    let target = complex(9.991328857359060844e-1, 1.790930224679519115e-4) #complex(2.009538984318353094, 5.633583284510720324e-01)
+    checkLambda(λ, target)
+    let λ2 = 4.263076242678597509e1.nm
+    let t2 = complex(7.746077971982764376e-01, 1.683285257772849097e-01)
+    let λ3 = 3.987909862920872683e+01.nm
+    let t3 = complex(7.946499269987641334e-01, 1.483447463676793865e-01)
+    checkLambda(λ2, t2)
+    checkLambda(λ3, t3)
+    let λ4 = 2.856648415496417215e+01.nm
+    let t4 = complex(8.737283973357047318e-01, 7.454228279449584549e-02)
+    checkLambda(λ4, t4)
+
+
+  #if true: quit()
+
+  let Γ = 0.45
+  let dMin = 11.5.nm
+  let dMax = 22.5.nm
+  let N = 2
+  var ds = @[dMax * Γ, dMax * (1.0 - Γ), dMin * Γ, dMin * (1.0 - Γ)]
+  let nVacuum = complex(1.0, 0.0) # vacuum
+  let energies = linspace(0.03, 10.0, 1000).mapIt(it.keV)
+  var RMs = newSeq[float]()
+  for i, E in energies:
+    # 1. compute the refractive indices for each layer
+    let nC = refractiveIndex(C, E, ρC)
+    let nPt = refractiveIndex(Pt, E, ρPt)
+    let nGlass = refractiveIndex(glass, E, ρGlass)
+    echo "-------------------- \n\n\n\n nC ", nC, " nPt ", nPt, " nGlass ", nGlass
+    let ns = @[nVacuum, nC, nPt, nC, nPt, nGlass]
+    RMs.add multilayerReflectivity(θ, E, ns, ds, parallel = false)
+
+  ggplot(toDf({"E" : energies.mapIt(it.float), "R" : RMs}), aes("E", "R")) +
+    geom_line() +
+    ggtitle("Reflectivity of LLNL recipe 1") +
+    ggsave("/tmp/llnl_reflectivity_1.pdf")
+
+
+
+#block NustarReflectivity:
+#  # initalize the elements of the substrate
+#  # m=drp.Multilayer(MultilayerType="DepthGraded",SubstrateMaterial="SiO2",LayerMaterial=["Pt","C"],Repetition=150,D_max=128.1,D_min=31.7,C=0.245,GammaTop=0.7,Gamma=0.45,SigmaValues=[4.5])
+#  let C = Carbon.init()
+#  let Pt = Platinum.init()
+#  let glass = compound((Si, 1), (O, 2)) # pure quartz glass
+#  const ρC = 2.26.g•cm⁻³ # 2.267 should be correct. used number same as DarpanX however
+#  const ρPt = 21.41.g•cm⁻³ # 21.45 should be correct. used number same as DarpanX however
+#  const ρGlass = 2.65.g•cm⁻³
+#  const θ = 0.5.°
+#
+#  let Γ = 0.45
+#  let dMin = 11.5.nm
+#  let dMax = 22.5.nm
+#  let N = 2
+#  var ds = @[10000.nm, dMax * Γ, dMax * (1.0 - Γ), dMin * Γ, dMin * (1.0 - Γ)]
+#  let nVacuum = complex(1.0, 0.0) # vacuum
+#  let energies = linspace(0.03, 10.0, 1000).mapIt(it.keV)
+#  var RMs = newSeq[float]()
+#  for i, E in energies:
+#    # 1. compute the refractive indices for each layer
+#    let nC = refractiveIndex(C, E, ρC)
+#    let nPt = refractiveIndex(Pt, E, ρPt)
+#    let nGlass = refractiveIndex(glass, E, ρGlass)
+#    echo "-------------------- \n\n\n\n nC ", nC, " nPt ", nPt, " nGlass ", nGlass
+#    let ns = @[nVacuum, nC, nPt, nC, nPt, nGlass]
+#    RMs.add multilayerReflectivity(θ, E, ns, ds)
+#
+#  ggplot(toDf({"E" : energies.mapIt(it.float), "R" : RMs}), aes("E", "R")) +
+#    geom_line() +
+#    ggtitle("Reflectivity of LLNL recipe 1") +
+#    ggsave("/tmp/llnl_reflectivity_1.pdf")

--- a/src/xrayAttenuation.nim
+++ b/src/xrayAttenuation.nim
@@ -436,6 +436,11 @@ proc molarWeight*(c: Compound): g•mol⁻¹ =
   for el, num in c:
     result += el.molarMass * num.float
 
+proc numAtoms*(c: Compound): int =
+  ## Returns the number of atoms in the compound
+  for _, num in c:
+    inc result, num
+
 proc atomicAbsorptionCrossSection*(el: AnyElement, energy: keV): cm² =
   ## Computes the atomic absoprtion cross section `σ_a` based on the scattering factor `f2`
   ## via

--- a/src/xrayAttenuation.nim
+++ b/src/xrayAttenuation.nim
@@ -261,6 +261,8 @@ proc name*(e: AnyElement | typedesc[AnyElement]): string =
   result = $typeof(e)
   if result.startsWith("Element["):
     result = $lookupInverseName(e)
+  elif result.startsWith("ElementRT"):
+    result = $e.chemSym
 
 proc Z*(e: AnyElement): int =
   ## Return the proton number of the given element. This is just the static

--- a/src/xrayAttenuation.nim
+++ b/src/xrayAttenuation.nim
@@ -34,7 +34,7 @@ type
   Compound* = object
     commonName: string # common name of the compound ("Water", "Salt", ...). Has to be user given
     elements: seq[NumberElement]
-    ρ: g•cm⁻³
+    ρ*: g•cm⁻³
 
   GasMixture* = object
     temperature*: Kelvin

--- a/src/xrayAttenuation.nim
+++ b/src/xrayAttenuation.nim
@@ -537,16 +537,26 @@ proc refractiveIndex*(c: Compound, energy: keV, ρ: g•cm⁻³): Complex[float]
     sumβδ += (1.0 - n) # correct `1 - (β + iδ)` computed in `refractiveIndex` to get `β + iδ`.
   result = 1.0 - sumβδ # compute back `n` from `1 - (β + iδ)`.
 
-proc reflectivity*(e: AnyElement, energy: keV, ρ: g•cm⁻³, θ: Degree, σ: Meter): float =
+proc reflectivity*(e: AnyElement, energy: keV, ρ: g•cm⁻³, θ: Degree, σ: Meter
+                   parallel: bool): float =
   ## Computes the reflectivity of the given element `e` at the boundary of vacuum to
-  ## a flat surface of `e` at the given `energy` and density `ρ`. `σ` is the surface
-  ## roughness and is the deviation from a perfectly smooth surface, approximated by
-  ## use of the Névot–Croce factor:
+  ## a flat surface of `e` at the given `energy` and density `ρ`.
+  ##
+  ## Computed for `p` polarization if `parallel = true`, else `s`-pol.
+  ##
+  ## `σ` is the surface roughness and is the deviation from a perfectly smooth surface,
+  ## approximated by use of the Névot–Croce factor:
   ##  `exp(-2 k_iz k_jz σ²)`
   ## where `k_iz`, `k_jz` are the wave vectors perpendicular to the surface in the medium
   ## before and after the interface between them.
   let n = e.refractiveIndex(energy, ρ)
+  result = reflectivity(θ, energy, n, σ, parallel = parallel)
+
+proc reflectivity*(e: AnyElement, energy: keV, ρ: g•cm⁻³, θ: Degree, σ: Meter): float =
+  ## Overload of the above, which computes it for unpolarized light.
+  let n = e.refractiveIndex(energy, ρ)
   result = reflectivity(θ, energy, n, σ)
+
 
 ################################
 ## Plotting related procs ######

--- a/src/xrayAttenuation.nim
+++ b/src/xrayAttenuation.nim
@@ -550,6 +550,25 @@ proc transmission*[L: Length, D: Density](c: AnyCompound, ρ: D, length: L, E: k
   let μ = c.attenuationCoefficient(E) # attenuation coefficient of the compound
   result = transmission(μ, ρ.to(g•cm⁻³), length.to(Meter))
 
+proc density*(gm: GasMixture): g•cm⁻³ =
+  ## Returns the density of the given gas mixture
+  for (g, r) in zip(gm.gases, gm.ratios):
+    let pr = gm.pressure * r # partial pressure of this gas
+    let ρr = density(pr, gm.temperature, g.molarWeight())
+    result += ρr
+
+template ρ*(gm: GasMixture): g•cm⁻³ = gm.density()
+
+proc transmission*[L: Length](gm: GasMixture, length: L, E: keV): float =
+  ## Computes the transmission using the Beer-Lambert law of photons of energy `E`
+  ## through the given gas mixture with density `ρ` and `length`.
+  let μ = gm.attenuationCoefficient(E) # attenuation coefficient of the compound
+  let ρ = density(gm)
+  ## XXX: Verify that this is actually correct! That we can just use the combined
+  ## attenuation coefficient like this! Looks correct for Ar/Iso, but that may be
+  ## due to the low fraction on isobutane!
+  result = transmission(μ / ρ, ρ.to(g•cm⁻³), length.to(Meter))
+
 proc absorptionLength*(c: AnyCompound, ρ: g•cm⁻³, energy: keV): Meter =
   ## Computes the absorption length of the given compound and density at `energy`.
   ##

--- a/src/xrayAttenuation.nim
+++ b/src/xrayAttenuation.nim
@@ -537,7 +537,7 @@ proc refractiveIndex*(c: Compound, energy: keV, ρ: g•cm⁻³): Complex[float]
     sumβδ += (1.0 - n) # correct `1 - (β + iδ)` computed in `refractiveIndex` to get `β + iδ`.
   result = 1.0 - sumβδ # compute back `n` from `1 - (β + iδ)`.
 
-proc reflectivity*(e: AnyElement, energy: keV, ρ: g•cm⁻³, θ: Degree, σ: Meter
+proc reflectivity*(e: AnyElement, energy: keV, ρ: g•cm⁻³, θ: Degree, σ: Meter,
                    parallel: bool): float =
   ## Computes the reflectivity of the given element `e` at the boundary of vacuum to
   ## a flat surface of `e` at the given `energy` and density `ρ`.

--- a/src/xrayAttenuation/macro_utils.nim
+++ b/src/xrayAttenuation/macro_utils.nim
@@ -47,3 +47,11 @@ proc genTypeClass*(e: var seq[NimNode]): NimNode =
     result = nnkInfix.newTree(ident"|",
                               genTypeClass(e),
                               el)
+
+proc getArgStr*(n: NimNode): string =
+  case n.kind
+  of nnkIdent, nnkSym,
+     nnkStrLit, nnkTripleStrLit, nnkRStrLit: result = n.strVal
+  of nnkOpenSymChoice, nnkClosedSymChoice: result = n[0].strVal
+  else:
+    error("Invalid node for argument `" & $(n.repr) & " in aes macro!")

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -337,7 +337,7 @@ proc multilayerReflectivity*(θ_i: Degree, energy: keV, ns: seq[Complex[float]],
   # = equal to refracted angle of layer _before_ substrate
   let sθ_last = refractedAngleSin(sθn_0, ns[0], ns[^2])
   # 3. refracted angle in substrate
-  let sθ_substrate = refractedAngle(sθn_0, ns[0], ns[^1])
+  let sθ_substrate = refractedAngleSin(sθn_0, ns[0], ns[^1])
   # 4. compute `r_j` (= reflectivity) of the substrate
   var r_j = reflectivity(sθ_last, ns[^2], sθ_substrate, ns[^1], energy, 0.0.m, parallel = parallel)
   # 5. loop back from layer _above_ substrate to first layer. `ns` has `N + 2`

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -129,7 +129,7 @@ proc refractiveIndex*(energy: keV, n_a: cm⁻³, f0: Complex[float]): Complex[fl
   ##
   ## NOTE: currently only for single elements
   let λ = wavelength(energy)
-  result = 1.0 - (r_e * λ * λ / (2 * π) * n_a).float * f0
+  result = 1.0 - (n_a * r_e * λ*λ / (2 * π) ) * f0
 
 proc waveNumber*(energy: keV, θ: Degree): m⁻¹ =
   ## Computes the wave number `k` for an incoming wave with `energy`

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -9,7 +9,7 @@ import unchained, math, complex
 ## Note: the naming of the procedures in here is verbose for clarity.
 ## More common abbreviations may be added as templates in the future.
 
-let R* = N_A * k_B # 8.314.J•K⁻¹•mol⁻¹ the universal Gas constant
+const R* = N_A * k_B # 8.314.J•K⁻¹•mol⁻¹ the universal Gas constant
 
 ## A bunch of units we use in this library. They have to be defined here,
 ## as they are used as arguments to procedures, which requires them to be

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -43,6 +43,10 @@ proc wavelength*(energy: keV): Meter =
   ## Compute the wavelength of the X-ray with the given `energy`.
   result = (hp * c / energy).to(Meter)
 
+proc energy*[L: Length](λ: L): keV =
+  ## Compute the wavelength of the X-ray with the given `energy`.
+  result = (hp * c / λ).to(keV)
+
 proc atomicAbsorptionCrossSection*(energy: keV, f2: UnitLess): cm² =
   ## Computes the atomic absoprtion cross section `σ_a` based on the scattering factor `f2`
   ## via

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -151,12 +151,37 @@ proc reflectivity*(θ: Degree, energy: keV, n: Complex[float], σ: Meter): float
   let kp = sqrt( (k*k).float * n*n - kθ*kθ )
   result = abs2( (km - kp) / (km + kp) )
 
-proc rij_s*(ni, nj: float, θ: Degree): float =
-  let niS = ni * sin(θ.to(Radian))
-  let njS = nj * sin(θ.to(Radian))
-  result = (niS - njS) / (niS + njS)
+proc refractedAngle*(θi: Degree, n_i, n_j: Complex[float]): Complex[float] =
+  ## Given the incidence angle `θi` returns the refracted angle according
+  ## to Snell's law for the materials with refractive indices `n_i` and `n_j`
+  ##
+  ## `n_i sin(θ_i) = n_j sin(θ_j)`
+  ## ⇒ `θ_j = arcsin(n_i sin(θ_i) / n_j)`
+  ##
+  ## `IMPORTANT`: The incident angle in this formulation is measured from the
+  ## normal of the interface! For grazing angles we typically measure from the
+  ## interface, so convert `90.° - θi` before calling!
+  ##
+  ## `IMPORTANT 2`: This procedure is unsafe in the contexts of total reflection,
+  ## i.e. for grazing angles if the `n_i > n_j` (vacuum to metal in X-ray regime
+  ## or glass to vacuum in visible light for example).
+  result = arcsin(n_i * sin(θ_i.to(Radian)) / n_j)
 
-#proc refR*(
+proc refractedAngleSin*(θi: Degree, n_i, n_j: Complex[float]): Complex[float] =
+  ## Given the incidence angle `θi` returns the sine of the refracted angle according
+  ## to Snell's law for the materials with refractive indices `n_i` and `n_j`
+  ##
+  ## `n_i sin(θ_i) = n_j sin(θ_j)`
+  ## ⇒ `sin(θ_j) = n_i sin(θ_i) / n_j`
+  ##
+  ## `IMPORTANT`: The incident angle in this formulation is measured from the
+  ## normal of the interface! For grazing angles we typically measure from the
+  ## interface, so convert `90.° - θi` before calling!
+  result = n_i * sin(θ_i.to(Radian)) / n_j
+
+proc refractedAngleSin*(sinθi: Complex[float], n_i, n_j: Complex[float]): Complex[float] =
+  ## Version of the above if `sin(θ_i)` is already given as complex number.
+  result = n_i * sinθi / n_j
 
 proc scatteringPotential(ρ: cm⁻³): m⁻² =
   result = (4*π * r_e * ρ).to(Meter⁻²)

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -354,3 +354,34 @@ proc multilayerReflectivity*(θ_i: Degree, energy: keV, ns: seq[Complex[float]],
     r_j = (r_ij + r_j * exp(im(1.0) * β_i)) / (1.0 + r_ij * r_j * exp(im(1.0) * β_i))
   # 4. once we are at the end of the loop, the last `r_j` is our final reflectivity
   result = abs2(r_j)
+
+proc depthGradedLayers*(d_min, d_max: NanoMeter, N: int, c: float): seq[NanoMeter] =
+  ## Computes the thickness of all layers in a depth graded multilayer, i.e.
+  ## the kind of multilayer coating where multiple repetitions of the material
+  ## are repeated with varying (increasing) thicknesses.
+  ## These are typically used to coat X-ray telescope to achieve a better
+  ## transmission over a wider range of energies and angles.
+  ##
+  ## A depth-graded multilayer is described by the equation:
+  ## \[
+  ## d_i = \frac{a}{(b + i)^c}
+  ## \]
+  ## where $d_i$ is the depth of layer $i$ (out of $N$ layers),
+  ## \[
+  ## a = d_{\text{min}} (b + N)^c
+  ## \]
+  ## and
+  ## \[
+  ## b = \frac{1 - N k}{k - 1}
+  ## \]
+  ## with
+  ## \[
+  ## k = \left(\frac{d_{\text{min}}}{d_{\text{max}}}\right)^{\frac{1}{c}}
+  ## \]
+  ## where $d_{\text{min}}$ and $d_{\text{max}}$ are the thickness of the
+  ## bottom and top most layers, respectively.
+  for i in 1 .. N:
+    let k = pow(d_min / d_max, 1.0 / c.float)
+    let b = (1.0 - N * k) / (k - 1.0)
+    let a = d_min * pow(b + N, c)
+    result.add a / pow(b + i.float, c)

--- a/src/xrayAttenuation/physics_utils.nim
+++ b/src/xrayAttenuation/physics_utils.nim
@@ -350,7 +350,7 @@ proc multilayerReflectivity*(θ_i: Degree, energy: keV, ns: seq[Complex[float]],
     let β_i = beta(sθi, ns[i], ds[i-1], λ.to(NanoMeter))
     # 2. compute `r_ij`
     let sθ_upper = refractedAngleSin(sθn_0, ns[0], ns[i-1]) # incidence angle of current interface
-    let r_ij = reflectivity(sθ_upper, ns[i-1], sθj, ns[i], energy, 0.0.m, parallel = parallel)
+    let r_ij = reflectivity(sθ_upper, ns[i-1], sθi, ns[i], energy, 0.0.m, parallel = parallel)
     # 3. assemble `r_j`
     r_j = (r_ij + r_j * exp(im(float) * β_i)) / (1.0 + r_ij * r_j * exp(im(float) * β_i))
   # 4. once we are at the end of the loop, the last `r_j` is our final reflectivity

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,7 +1,17 @@
-import unittest
-import datamancer
+import std / [unittest, math]
+import ../src/xrayAttenuation
+
+import ggplotnim except almostEqual
+import unchained
 
 ## A few simple tests
+
+proc `=~=`[T: not seq](x, y: T): bool = almostEqual(x.float, y.float, epsilon = 3)
+proc `=~=`[T](x, y: seq[T]): bool =
+  check x.len == y.len
+  result = true
+  for i in 0 ..< x.len:
+    result = result and x[i] =~= y[i]
 
 suite "Basic physics utility procs":
   test "density":
@@ -54,10 +64,13 @@ suite "Basic physics utility procs":
     discard
     # check reflectivity(θ, energy, n, σ) ==
 
-# import unittest
-
-import xrayAttenuation, ggplotnim, unchained
-
+  test "Depth graded multilayers":
+    ## The following are the depth graded values for the LLNL telescope
+    ## following a NuSTAR designed for the CAST experiment.
+    check depthGradedLayers(d_min = 11.5.nm, d_max = 22.5.nm, N = 2, c = 1.0) =~= @[22.5.nm, 11.5.nm]
+    check depthGradedLayers(d_min = 7.0.nm, d_max = 19.0.nm, N = 3, c = 1.0)  =~= @[19.nm, 10.2308.nm, 7.nm]
+    check depthGradedLayers(d_min = 5.5.nm, d_max = 16.0.nm, N = 4, c = 1.0)  =~= @[16.nm, 9.77778.nm, 7.04.nm, 5.5.nm]
+    check depthGradedLayers(d_min = 5.0.nm, d_max = 14.0.nm, N = 5, c = 1.0)  =~= @[14.nm, 9.65517.nm, 7.36842.nm, 5.95745.nm, 5.nm]
 
 let ar = Argon.init()
 var dfBoth = newDataFrame()


### PR DESCRIPTION
Mainly adds support for multilayer reflectivities, e.g. to compute reflectivity of depth grade multilayer systems as used in many modern X-ray telescopes (NuSTAR, ...).

In addition adds some related helpers and features. Reflectivities are now computed directly from the Fresnell equations allowing to separately consider s- or p-polarization.