### PR TITLE
Static build support, default to runtime elements (with CT wrapper), ...

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,16 @@
+* v0.4.0
+- add ~staticBuild~ option and default to runtime elements.
+  -> Compile with ~-d:staticBuild~ to read all data files at compile
+  time to have a binary that can be moved around without shipping
+  the CSV data files.
+- add ~pairs~ iterator for ~GasMixture~ and export one for ~Compound~  
+- add helper ~pressure~ to compute pressure given temp and density
+- move ~getFluorescenceLines~ above the plotting helpers
+- deprecated molarWeight for compounds (-> molarMass), add for gases
+- do not default to 3 digits of precision for gas mixtures
+- minor fixes in ~compound~ macro for construction
+- add helper to parse a compound from a given string
+- give runtime elements their name as field
 * v0.3.1
 - fix project structure to follow annoying nimble rules
 - add missing dependencies

--- a/examples/calc_gas_mixture_fractions.nim
+++ b/examples/calc_gas_mixture_fractions.nim
@@ -1,0 +1,113 @@
+import xrayAttenuation, datamancer, unchained
+import std / [strformat, terminal, strutils]
+from std / sequtils import mapIt
+
+#[
+nim musl -d:release -d:staticBuild calc_density_fraction
+]#
+
+proc getMassFractions(c: AnyCompound): seq[(string, float)] =
+  ## Computes the mass fractions of all elements inside of a compound.
+  for el, num in c:
+    let fraction = el.molarMass * num / molarWeight(c) # fraction of particles of this type
+    result.add (el.name(), fraction.float)
+
+proc getFractions(gm: GasMixture): seq[(string, float)] =
+  ## Computes the particle fractions for a gas mixture (i.e. the fractions used
+  ## for partial pressures), *BUT* with the addition that the individual compounds
+  ## in a gas, i.e. Isobutane, are split up *BY MASS FRACTION* as well. This is
+  ## very confusing and wrong (because ideal gas physics only cares about the
+  ## number of *particles*, whether they be atoms or molecules), but this is what
+  ## was done in REST in the past.
+  for c, ratio in gm:
+    for (el, frac) in getMassFractions(c):
+      result.add (el, frac * ratio)
+
+proc getMassFractions(gm: GasMixture): seq[(string, float)] =
+  ## We compute the gas mass fraction as:
+  ##
+  ## f_m,k = X_k * M_k / M_gm                  (1)
+  ##
+  ## with `X_k` the fractional number of particles of that part of the gas
+  ## compound, `M_k` the molar mass of the compound in the gas and `M_gm` the
+  ## total molar mass of the gas mixture.
+  ##
+  ## For individual atoms of a compound, i.e. C in Ar 97.7 / Isobutane 2.3 (C4H10)
+  ## it is further split by the individual fractions based on the weighted masses
+  ## in the compound.
+  ##
+  ## fm_k = f_m,c * N_c * A_c * M_u / M_c       (2)
+  ##
+  ## where `f_m,c` is the mass fraction of the compound e.g. Isobutane following eq. (1)
+  ## and `N_c` the number of atoms of the compound, e.g. `4` carbon per isobutane
+  ## `A_c` the standard atomic weight e.g. `~12.011` for carbon and `M_u` the
+  ## molar mass constant (prior 2019 redefinition `1 g/mol`) and `M_c` the
+  ## molar mass of the compound (e.g. `58.12 g•mol⁻¹` for Isobutane).
+  for c, ratio in gm:
+    for (el, cFrac) in getMassFractions(c): # cFrac == compound fraction
+      let fraction = cFrac * ratio * molarMass(c) / molarMass(gm)
+      result.add (el, float fraction)
+
+proc gas(elements: seq[string], pressure: mbar, T = 293.15.K) =
+  var gases: seq[Compound]
+  var frac: seq[float]
+  for el in elements:
+    let sp = el.split(",").mapIt(it.strip)
+    let elRTs = parseCompound(sp[0])
+    let fr = parseFloat sp[1]
+
+    gases.add initCompound(0.0.g•cm⁻³, elRTs)
+    if fr > 1.0:
+      echo "[ERROR] Pleas give the gas fractions as relative to 1.0 and not as percentages."
+      return
+    frac.add fr
+
+  if abs(frac.sum - 1) > 1e-4:
+    echo frac.sum
+    echo "From numbers: ", frac
+    echo "[ERROR] The gas mixture fractions do not sum to 1!"
+    return
+
+  let gm = initGasMixture(T, pressure, gases, frac)
+  stdout.styledWriteLine(fgYellow, "==================== Gas ====================")
+  stdout.styledWriteLine(fgYellow, &"\t{gm}")
+  stdout.styledWriteLine(fgYellow, &"\tρ = {gm.ρ.to(kg•m⁻³)}")
+  stdout.styledWriteLine(fgRed, "---------- Particle fractions ----------")
+  for fr in getFractions(gm):
+    stdout.styledWriteLine(fgRed, &"\t{fr[0]:<2}: {fr[1]}")
+  stdout.styledWriteLine(fgRed, "------------ Mass fractions ------------")
+  for fr in getMassFractions(gm):
+    stdout.styledWriteLine(fgRed, &"\t{fr[0]:<2}: {fr[1]}")
+
+proc solid(elements: seq[string], ρ = -1.0.g•cm⁻³) =
+  var elRT: seq[(ElementRT, int)]
+  for el in elements:
+    elRT.add parseCompound(el)
+
+  var comp = initCompound(ρ, elRT)
+  stdout.styledWriteLine(fgYellow, "==================== Solid ====================")
+  stdout.styledWriteLine(fgYellow, &"\t{comp}")
+  stdout.styledWriteLine(fgYellow, &"\tρ = {comp.ρ.to(g•cm⁻³)}")
+  stdout.styledWriteLine(fgRed, "------------ Mass fractions ------------")
+  for el, fr in getMassFractions(comp):
+    stdout.styledWriteLine(fgRed, &"\t{el:<2}: {fr}")
+
+when isMainModule:
+  import cligen
+  import unchained / cligenParseUnits
+  dispatchMulti([gas,
+                 help = {
+                   "elements" : """Give each part of the gas as a pair 'compound,fraction'
+Example: Ar,0.977 C4H10,0.023
+
+For molecular gases (in the example isobutane), simply provide the formula of the molecule.
+""",
+                   "pressure" : "The pressure of the gas in MilliBar.",
+                   "T"        : "The temperature of the gas in Kelvin."
+                   }
+                ],
+                [solid,
+                 help = {
+                   "elements" : "Give each element part of the compound as a simplified chemical formula. Example: C6H10",
+                   "ρ"        : "Density of the compound."}
+                 ])

--- a/xrayAttenuation.nim
+++ b/xrayAttenuation.nim
@@ -15,6 +15,7 @@ and Henke files based on form factors `f1, f2` for energies from 10 eV to 30 keV
 
 type
   ElementRT* = object
+    name*: string # name of the element
     nProtons*: int ## runtime value of `Z`. Different name to not clash with `Z` static
     nistDf*: DataFrame # stores lines, μ/ρ (raw data from NIST TSV file)
     nistFormFactorDf*: DataFrame # stores lines, μ/ρ (raw data from NIST TSV file)

--- a/xrayAttenuation.nim
+++ b/xrayAttenuation.nim
@@ -546,9 +546,9 @@ proc parseCompound*(s: string): seq[(ElementRT, int)] =
   else:
     result.add (initElement(chemSym), 1)
 
-proc initCompound*(name: string): Compound =
+proc initCompound*(ρ: g•cm⁻³, name: string): Compound =
   ## Initializes a compound from a string, i.e. `H2O`, `CO2`, `Si3N4`, ...
-  result = parseCompound(name)
+  result = initCompound(ρ, parseCompound(name))
 
 proc initGasMixture*[P: Pressure](
   T: Kelvin,

--- a/xrayAttenuation.nim
+++ b/xrayAttenuation.nim
@@ -668,7 +668,7 @@ proc pretty*(gm: GasMixture, showPrefix: bool): string =
   if showPrefix:
     result = "GasMixture: "
   for i, x in gm.gases:
-    result.add &"{x} ({gm.ratios[i]:.3f})"
+    result.add &"{x} ({gm.ratios[i]})"
     if i < gm.gases.len:
       result.add ", "
   result.add &"(T = {gm.temperature}, P = {gm.pressure})"

--- a/xrayAttenuation.nim
+++ b/xrayAttenuation.nim
@@ -700,17 +700,27 @@ proc name*(c: Compound): string = $c
 ################################
 ## Physics related procedures ##
 ################################
-proc molarWeight*(c: Compound): g•mol⁻¹ =
-  ## Computes the molar weight of the compound:
+proc molarMass*(c: Compound): g•mol⁻¹ =
+  ## Computes the molar mass of the compound:
   ##
-  ## `MW = Σ_i x_i · A_i`
+  ## `M = Σ_i x_i · A_i`
   ## where `x_i` is the number of atoms of that type in the compound
-  ## and `A_i` the atomic mass of each atom in `g•mol⁻¹`.
+  ## and `A_i` the atomic mass of each atom in `g•mol⁻¹`
+  ## (with `A_i = A_r,i · M_u` where `A_r,i` is the standard atomic weight
+  ## of the element and `M_u =~= 1 g•mol⁻¹` the molar mass constant).
   for el, num in c:
     result += el.molarMass * num.float
 
+proc molarWeight*(c: Compound): g•mol⁻¹ {.deprecated: "Please use `molarMass(Compound)` instead.".} =
+  molarMass(c)
+
+proc molarMass*(gm: GasMixture): g•mol⁻¹ =
+  ## Computes the molar weight of a gas mixture.
+  for c, ratio in gm:
+    result += c.molarWeight() * ratio
+
 proc numAtoms*(c: Compound): int =
-  ## Returns the number of atoms in the compound
+  ## Returns the number of atoms in the compound.
   for _, num in c:
     inc result, num
 

--- a/xrayAttenuation.nim
+++ b/xrayAttenuation.nim
@@ -618,7 +618,7 @@ macro compound*(args: varargs[untyped]): untyped =
     var chemSym: string
     case arg.kind
     of nnkTupleConstr:
-      doAssert arg[0].kind == nnkIdent
+      doAssert arg[0].kind in {nnkIdent, nnkSym}
       doAssert arg[1].kind == nnkIntLit
       chemSym = arg[0].strVal
       number = arg[1].intVal.int
@@ -632,7 +632,7 @@ macro compound*(args: varargs[untyped]): untyped =
       # skip the rest of this iteration
       continue
     of nnkIdent:
-      let chemSym = arg.strVal
+      chemSym = arg.strVal
     else:
       error("The `compound` macro receives either a tuple of chemical symbol and number " &
         "of atoms `(H, 2)` or only a chemical symbol `O`.")

--- a/xrayAttenuation.nim
+++ b/xrayAttenuation.nim
@@ -50,11 +50,15 @@ type
     energy*: keV
     intensity*: float # relative intesity compared to *other lines of the same shell*
 
-iterator pairs(c: Compound): (ElementRT, int) =
+iterator pairs*(c: Compound): (ElementRT, int) =
   for (el, num) in c.elements:
     yield (el, num)
 
-const Resources = currentSourcePath().parentDir() / "xrayAttenuation" / "resources"
+iterator pairs*(gm: GasMixture): (Compound, float) =
+  for (c, ratio) in zip(gm.gases, gm.ratios):
+    yield (c, ratio)
+
+const Resources = currentSourcePath().parentDir() / "xrayAttenuation" / "resources/"
 const NIST = "nist_mass_attenuation"
 const Henke = "henke_form_factors"
 const NIST_scattering_factors = "nist_form_factors"

--- a/xrayAttenuation/physics_utils.nim
+++ b/xrayAttenuation/physics_utils.nim
@@ -34,6 +34,13 @@ proc density*[P: Pressure](p: P, T: Kelvin, M: g•mol⁻¹): g•cm⁻³ =
   ## unit), temperature `T` and molar mass `M`.
   result = (p * M / (R * T)).to(g•cm⁻³)
 
+proc pressure*[Rho: Density](ρ: Rho, T: Kelvin, M: g•mol⁻¹): mbar =
+  ## Compute the pressure `P` given a density `ρ` using the ideal gas law at the given
+  ## temperature `T` and  molar mass `M`.
+  # ρ = p * M / (R * T) ⇔
+  # p = ρ * R * T / M
+  result = (ρ * R * T / M).to(mbar)
+
 proc numberDensity*(ρ: g•cm⁻³, M: g•mol⁻¹): cm⁻³ =
   ## Computes the number density of a medium with density `ρ` and molar mass
   ## `M`. That is the number of particles in a unit volume (of `cm⁻³` in this case).


### PR DESCRIPTION
The biggest changes in this PR:

1. Previous to this PR our default were compile time elements with
an option to convert those to runtime values. This had some negative
side effects, making performance much worse when dealing with many
elements. Now, we do all the hard work at runtime and simply have a
thin compile time safe wrapper around the elements with a static size
argument.

2. This adds the `-d:staticBuild` option, which slurps all the data
files in the `resources` directory so that we can have an independent
build that includes all data files. This is very handy when compiling
with musl for a fully static executable.


Aside from that:
- a `pressure` proc to compute corresponding pressure given a density and temperature
- parser for a compounds from a string, i.e. `H2O` etc
- `molarMass` for a gas mixture
- deprecated `molarWeight` in favor of `molarMass` for compounds