### PR TITLE
Fixup transmission fnames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,8 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           body: |
-            Release notes for version ${{ github.ref }}
+            Release notes for version ${{ github.ref }}. See the \
+            changelog.org file for more information.
           draft: false
           prerelease: false
 

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.4.2
+- change ~examples/calc_gas_mixtures.nim~ to not use half width space
+  in filenames, use dot instead
 * v0.4.1
 - add basic CI running test / playground
 - compile examples as static linux binary

--- a/examples/calc_gas_mixtures.nim
+++ b/examples/calc_gas_mixtures.nim
@@ -48,6 +48,7 @@ proc getMassFractions(gm: GasMixture): seq[(string, float)] =
       let fraction = cFrac * ratio * molarMass(c) / molarMass(gm)
       result.add (el, float fraction)
 
+proc unitToFname[T: SomeUnit](s: T): string = result = $s.float & "." & unitOf(s)
 proc genOutfile(gm: GasMixture, outfile, outdir: string): string =
   if outfile.len > 0: result = outfile
   else:
@@ -55,7 +56,7 @@ proc genOutfile(gm: GasMixture, outfile, outdir: string): string =
     result.add "transmission"
     for el, frac in gm:
       result.add &"_{el}_{frac}"
-    result.add &"_{gm.pressure}_{gm.temperature}"
+    result.add &"_{unitToFname gm.pressure}_{unitToFname gm.temperature}"
     result.add ".csv"
 
 proc calcTransmission(gm: GasMixture, length: cm, energyMin, energyMax: keV, num: int, outfile: string) =


### PR DESCRIPTION
The filenames in `examples/calc_gas_mixtures.nim` included unicode characters from the stringification of units, i.e. the half width space ` `. This replaces that by a dot.